### PR TITLE
Test PR3

### DIFF
--- a/app/src/test/java/com/panatchai/abcnews/util/ErrorUtilTest.kt
+++ b/app/src/test/java/com/panatchai/abcnews/util/ErrorUtilTest.kt
@@ -19,4 +19,10 @@ class ErrorUtilTest {
         val t = Throwable()
         assertThat(t.getErrorMessage(), `is`("unknown error"))
     }
+
+    @Test
+    fun GivenNullThrowable_ReturnUnknownErrorMessage() {
+        val t = Throwable()
+        assertThat(t.getErrorMessage(), `is`("unknown error"))
+    }
 }


### PR DESCRIPTION
Test when the throwable is null, check if returns the default error message.

- app/src/test/java/com/panatchai/abcnews/util/ErrorUtilTest.kt
  Test when the throwable is null, check if returns the default error message.